### PR TITLE
Knife damage DMG_SLASH instead of DMG_BULLET

### DIFF
--- a/lua/weapons/csgo_baseknife.lua
+++ b/lua/weapons/csgo_baseknife.lua
@@ -316,7 +316,7 @@ function SWEP:DoAttack( Altfire )
   damageinfo:SetAttacker( Attacker )
   damageinfo:SetInflictor( self )
   damageinfo:SetDamage( Damage )
-  damageinfo:SetDamageType( bit.bor( DMG_BULLET , DMG_NEVERGIB ) )
+  damageinfo:SetDamageType( bit.bor( DMG_SLASH , DMG_NEVERGIB ) )
   damageinfo:SetDamageForce( Force )
   damageinfo:SetDamagePosition( AttackEnd )
 


### PR DESCRIPTION
Many workshop addons use DMG_SLASH to check if damage dealt is from a melee source. Makes no sense to use DMG_BULLET here.